### PR TITLE
Change LED on start/stop

### DIFF
--- a/install/on_rpi/remapper.service
+++ b/install/on_rpi/remapper.service
@@ -5,6 +5,8 @@ After=multi-user.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/python3 /home/pi/bthidhub/remapper.py
+ExecStartPost=/usr/bin/bash -c 'echo none > /sys/class/leds/led0/trigger'
+ExecStopPost=/usr/bin/bash -c 'echo heartbeat > /sys/class/leds/led0/trigger'
 WorkingDirectory=/home/pi/bthidhub
 Restart=on-abort
  


### PR DESCRIPTION
I noticed you disabled the LED in the setup script, but that doesn't persist after reboot, so thought I'd add something more permanent.

Expected behaviour is that the LED comes up when booting, but switches off once the service is running. As a bonus, it will also flash if the service gets stopped for some reason, providing a warning to the user.