### PR TITLE
Quit on SIGINT

### DIFF
--- a/remapper.py
+++ b/remapper.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2020 ruundii. All rights reserved.
 
-from dasbus.connection import SystemMessageBus
-from web import Web
 import asyncio
+import sys
+from signal import SIGINT
+
 import asyncio_glib
+from dasbus.connection import SystemMessageBus
+
 from adapter import BluetoothAdapter
-from hid_devices import *
 from bluetooth_devices import *
+from hid_devices import *
+from web import Web
 
 if __name__ == "__main__":
     asyncio.set_event_loop_policy(asyncio_glib.GLibEventLoopPolicy())
     loop = asyncio.get_event_loop()
+    loop.add_signal_handler(SIGINT, sys.exit)
     bus = SystemMessageBus()
     bluetooth_devices = BluetoothDeviceRegistry(bus, loop)
     hid_devices = HIDDeviceRegistry(loop)


### PR DESCRIPTION
This makes development easier by allowing the application to be quit cleanly with Ctrl+C. Not entirely sure why this doesn't happen by default, but probably due to using the low-level asyncio loop methods.